### PR TITLE
return error when the message does not meet the template

### DIFF
--- a/splunk.go
+++ b/splunk.go
@@ -50,8 +50,13 @@ func (sw *Writer) Write(entry tracer.Entry) {
 		}
 
 		properties := NewEntry(append(entry.Args, sw.defaultPropertiesApp))
+
 		message := punctuation.FindStringSubmatch(s.Capitalize(entry.Message))[1]
-		message = s.ProcessString(r.Replace(message), properties)
+
+		message, err := s.ProcessString(r.Replace(message), properties)
+		if err != nil {
+			message = entry.Message
+		}
 
 		l := NewEntry(sw.configLineLog)
 		l.Add("time", time.Now().UTC().UnixNano())

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -2,7 +2,6 @@ package strings
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 	"regexp"
 	"strings"
@@ -35,21 +34,21 @@ func Capitalize(str string) string {
 	return strings.ToUpper(string(str[0])) + str[1:]
 }
 
-func ProcessString(str string, vars interface{}) string {
+func ProcessString(str string, vars interface{}) (string, error) {
 	tmpl, err := template.New("tmpl").Parse(str)
 
 	if err != nil {
-		fmt.Println(err.Error())
+		return "", err
 	}
 	return process(tmpl, vars)
 }
 
-func process(t *template.Template, vars interface{}) string {
+func process(t *template.Template, vars interface{}) (string, error) {
 	var tmplBytes bytes.Buffer
 
 	err := t.Execute(&tmplBytes, vars)
 	if err != nil {
-		fmt.Println(err.Error())
+		return "", err
 	}
-	return tmplBytes.String()
+	return tmplBytes.String(), nil
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Return error when the message does not meet the template standard.
| **Why?**          | The app broke when the message contains brackets
| **How?**          | Implement error validate when the message does not meet the template standard.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)
Add additional informations like screenshots, issue link, etc

#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!