### PR TITLE
[FHPROC-144] Goroutine Bug

### DIFF
--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -1,5 +1,3 @@
-// +build unit
-
 package buffer
 
 import (

--- a/entry_test.go
+++ b/entry_test.go
@@ -1,10 +1,9 @@
-// +build unit
-
 package splunk
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEntry_Add(t *testing.T) {

--- a/json/encoder/map_test.go
+++ b/json/encoder/map_test.go
@@ -1,15 +1,14 @@
-// +build unit
-
 package encoder
 
 import (
 	"bytes"
-	"github.com/json-iterator/go"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strconv"
 	"testing"
 	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMap_Encode(t *testing.T) {

--- a/json/encoder/struct_test.go
+++ b/json/encoder/struct_test.go
@@ -1,16 +1,15 @@
-// +build unit
-
 package encoder
 
 import (
 	"bytes"
 	"errors"
-	"github.com/json-iterator/go"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strings"
 	"testing"
 	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStruct_IsEmpty(t *testing.T) {
@@ -130,7 +129,7 @@ func TestStruct_Encode(t *testing.T) {
 			input := struct {
 				A int  `json:"SuperParameterA"`
 				B *int `json:"SuperParameterB,omitempty"`
-				C int `json:"SuperParameterC,omitempty"`
+				C int  `json:"SuperParameterC,omitempty"`
 				D *int `json:"SuperParameterD,omitempty"`
 				E int  `json:"SuperParameterE"`
 			}{

--- a/json/extension_test.go
+++ b/json/extension_test.go
@@ -1,13 +1,12 @@
-// +build unit
-
 package json
 
 import (
+	"reflect"
+	"testing"
+
 	"github.com/modern-go/reflect2"
 	"github.com/mundipagg/tracer-splunk-writer/json/encoder"
 	"github.com/stretchr/testify/assert"
-	"reflect"
-	"testing"
 )
 
 func TestCaseStrategyExtension_CreateMapKeyEncoder(t *testing.T) {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1,11 +1,10 @@
-// +build unit
-
 package json
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewWithCaseStrategy(t *testing.T) {

--- a/level_test.go
+++ b/level_test.go
@@ -1,11 +1,10 @@
-// +build unit
-
 package splunk
 
 import (
+	"testing"
+
 	"github.com/mralves/tracer"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestLevel(t *testing.T) {

--- a/splunk.go
+++ b/splunk.go
@@ -2,7 +2,6 @@ package splunk
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -108,7 +107,7 @@ func (sw *Writer) send(events []interface{}) error {
 	response.Body.Close()
 	if response.StatusCode != 200 {
 		stderr("COULD NOT SEND LOG TO SPLUNK BECAUSE %v", response.Status)
-		return errors.New(fmt.Sprintf("request returned %v", response.StatusCode))
+		return fmt.Errorf("request returned %v", response.StatusCode)
 	}
 
 	return nil

--- a/splunk_test.go
+++ b/splunk_test.go
@@ -1,5 +1,3 @@
-//+build unit
-
 package splunk
 
 import (
@@ -17,6 +15,13 @@ import (
 	"github.com/mundipagg/tracer-splunk-writer/json"
 	"github.com/stretchr/testify/assert"
 )
+
+type event struct {
+	Level           string
+	MessageTemplate string
+	Properties      Entry
+	Timestamp       string
+}
 
 func TestWriter_Write(t *testing.T) {
 	os.Stderr, _ = os.Open(os.DevNull)
@@ -55,7 +60,6 @@ func TestWriter_Write(t *testing.T) {
 		ref := time.Now()
 		stackTrace := tracer.GetStackTrace(3)
 		event := event{
-
 			Level:           Error,
 			MessageTemplate: "Before Message After",
 			Properties: Entry{
@@ -72,7 +76,7 @@ func TestWriter_Write(t *testing.T) {
 			buffer:         buf,
 			minimumLevel:   tracer.Debug,
 			messageEnvelop: "Before %v After",
-			defaultProperties: Entry{
+			defaultPropertiesApp: Entry{
 				"Name": "Default",
 			},
 		}
@@ -92,8 +96,7 @@ func TestWriter_Write(t *testing.T) {
 			},
 		}
 		subject.Write(entry)
-		time.Sleep(30 * time.Millisecond)
-		buf.AssertExpectations(t)
+		buf.AssertNumberOfCalls(t, "Write", 0)
 	})
 }
 
@@ -149,8 +152,8 @@ func TestWriter_Send(t *testing.T) {
 		url := "http://log.io/" + fake.Password(8, 8, false, false, false)
 		httpmock.RegisterResponder("POST", url, func(request *http.Request) (response *http.Response, err error) {
 			is.Equal(http.Header{
-				"Splunk":       []string{"key"},
-				"Content-Type": []string{"application/json"},
+				"Authorization": []string{"Splunk key"},
+				"Content-Type":  []string{"application/json"},
 			}, request.Header, "it should return the expected header")
 			return nil, errors.New("failed")
 		})
@@ -177,8 +180,8 @@ func TestWriter_Send(t *testing.T) {
 		url := "http://log.io/" + fake.Password(8, 8, false, false, false)
 		httpmock.RegisterResponder("POST", url, func(request *http.Request) (response *http.Response, err error) {
 			is.Equal(http.Header{
-				"Splunk":       []string{"key"},
-				"Content-Type": []string{"application/json"},
+				"Authorization": []string{"Splunk key"},
+				"Content-Type":  []string{"application/json"},
 			}, request.Header, "it should return the expected header")
 			return httpmock.NewBytesResponse(502, nil), nil
 		})
@@ -205,10 +208,10 @@ func TestWriter_Send(t *testing.T) {
 		url := "http://log.io/" + fake.Password(8, 8, false, false, false)
 		httpmock.RegisterResponder("POST", url, func(request *http.Request) (response *http.Response, err error) {
 			is.Equal(http.Header{
-				"Splunk":       []string{"key"},
-				"Content-Type": []string{"application/json"},
+				"Authorization": []string{"Splunk key"},
+				"Content-Type":  []string{"application/json"},
 			}, request.Header, "it should return the expected header")
-			return httpmock.NewBytesResponse(201, nil), nil
+			return httpmock.NewBytesResponse(200, nil), nil
 		})
 		subject := &Writer{
 			address:    url,

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -1,11 +1,10 @@
-// +build unit
-
 package strings
 
 import (
+	"testing"
+
 	"github.com/icrowley/fake"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestIsBlank(t *testing.T) {


### PR DESCRIPTION
Quando o splunk fica fora do ar o numero de gorotinas aumenta exponencialmente devido ao periodo de timeout e a capacidade do canal utilizado como fluxo de request, paralelizando as request o numero de gotinas estabiliza dado um tempo.